### PR TITLE
Formatting cleanup

### DIFF
--- a/docs/chapter01/README.md
+++ b/docs/chapter01/README.md
@@ -270,6 +270,7 @@ Later on, we will also put stuff in between the start and the end of the render 
 
 And then finally, outside the swapchain's if-statement again, we can say we are done with filling in the command buffer.
 While saying that, we also finally send it off to the GPU for processing.
+
 ```c++
 SDL_SubmitGPUCommandBuffer(commandBuffer);
 ```
@@ -285,11 +286,13 @@ MyAppState* myAppState = static_cast<MyAppState*>(appstate);
 ```
 
 With that, we can now deattach the GPU Device from the Window again:
+
 ```c++
 SDL_ReleaseWindowFromGPUDevice(myAppState->device, myAppState->window);
 ```
 
 And then clean them up:
+
 ```c++
 SDL_DestroyWindow(myAppState->window);
 SDL_DestroyGPUDevice(myAppState->device);

--- a/docs/chapter01/README.md
+++ b/docs/chapter01/README.md
@@ -277,6 +277,7 @@ SDL_SubmitGPUCommandBuffer(commandBuffer);
 Right now, you could already run the code, but we haven't done out cleanup yet, so hold on for a few more moments!
 
 ## Cleanup
+
 In your `SDL_AppQuit` function, get the pointer to your MyAppState instance back from SDL:
 
 ```c++


### PR DESCRIPTION
There are 2 small formatting changes in this PR, both of them are on the "Chapter 1: Blank Screen" page.

1. There was a missing line break after a heading, and every other heading has one.
2. There was a missing line break before 3 of the code blocks, and every other code block (the remaining 14 ones) had a line break before it.